### PR TITLE
Upgrade to Node 16 [CORE-81]

### DIFF
--- a/lambda-packages/template.yml
+++ b/lambda-packages/template.yml
@@ -3,7 +3,7 @@ Transform: AWS::Serverless-2016-10-31
 
 Globals:
   Function:
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 900
       Handler: index.handler
 


### PR DESCRIPTION
### What does it do? Why?

Use Node 16 instead of Node 12 that is no more supported by AWS lambdas
